### PR TITLE
#289 Update beamlettest expected init condition after version updates

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "Python 3",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/python:2-3.9-bullseye",
+	"features": {
+		"ghcr.io/devcontainers/features/python:1": {
+			"installTools": true,
+			"version": "3.9"
+		}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "pip3 install --user -r requirements.txt"
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.github/workflows/renate-od.yml
+++ b/.github/workflows/renate-od.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4

--- a/crm_solver/beamlettest.py
+++ b/crm_solver/beamlettest.py
@@ -8,7 +8,7 @@ import numpy
 
 class BeamletTest(unittest.TestCase):
     EXPECTED_ATTR = ['param', 'components', 'profiles', 'coefficient_matrix', 'atomic_db', 'initial_condition']
-    EXPECTED_INITIAL_CONDITION = [4832583106.4753895, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    EXPECTED_INITIAL_CONDITION = [4832583046.75342, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
     EXPECTED_PARAM_ATTR = ['beamlet_source', 'beamlet_energy', 'beamlet_species', 'beamlet_current']
     EXPECTED_COMPONENTS_KEYS = ['q', 'Z', 'A']
     EXPECTED_COMPONENTS_SPECIES = ['electron', 'ion1', 'ion2']
@@ -42,8 +42,8 @@ class BeamletTest(unittest.TestCase):
         for element in range(len(self.beamlet.initial_condition)):
             self.assertIsInstance(self.beamlet.initial_condition[element], float, msg='Expected type for initial'
                                                                                       ' conditions is float.')
-            self.assertEqual(self.beamlet.initial_condition[element], self.EXPECTED_INITIAL_CONDITION[element],
-                             msg='Computed Init conditions do not match expected init conditions.')
+            self.assertAlmostEqual(self.beamlet.initial_condition[element], self.EXPECTED_INITIAL_CONDITION[element],
+                             delta=1e-1, msg='Computed Init conditions do not match expected init conditions.')
 
     def test_param_xml(self):
         self.assertIsInstance(self.beamlet.param, etree._ElementTree,


### PR DESCRIPTION
Besides fixing the unittest, also added a devcontainer.json that allows creating a codespace on GitHub. Specified the explicit ubuntu version for the unittest environment to make sure that the OS doesn't silently change in a few months when 26.04 comes out.